### PR TITLE
Feature - Expand Foreign Keys

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -36,7 +36,7 @@ class JSONServer(HandleRequests):
 
         elif url["requested_resource"] == "ships":
             if url["pk"] != 0:
-                response_body = retrieve_ship(url["pk"])
+                response_body = retrieve_ship(url)
                 return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
             response_body = list_ships(url)

--- a/json-server.py
+++ b/json-server.py
@@ -39,7 +39,7 @@ class JSONServer(HandleRequests):
                 response_body = retrieve_ship(url["pk"])
                 return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
-            response_body = list_ships()
+            response_body = list_ships(url)
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
         else:

--- a/views/ship_view.py
+++ b/views/ship_view.py
@@ -41,12 +41,10 @@ def list_ships(url):
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
 
-        expand_list = url["query_params"].get("_expand", [])
+        query_params = url["query_params"].get("_expand", [])
 
         # Check if query is requesting expanded data
-        # if "hauler" in url["query_params"]["_expand"]:
-        if "hauler" in expand_list:
-            # Write the SQL query to get the information you want
+        if "hauler" in query_params:
             db_cursor.execute("""
             SELECT
                 s.id,
@@ -60,7 +58,6 @@ def list_ships(url):
                 ON h.id = s.hauler_id
             """)
         else:
-            # Write the SQL query to get the information you want
             db_cursor.execute("""
             SELECT
                 s.id,
@@ -79,7 +76,7 @@ def list_ships(url):
                 "name": row['name'],
                 "hauler_id": row["hauler_id"]
             }
-            if "hauler" in expand_list:
+            if "hauler" in query_params:
                 hauler = {
                     "id": row['haulerId'],
                     "name": row['haulerName'],
@@ -93,26 +90,62 @@ def list_ships(url):
 
     return serialized_ships
 
-def retrieve_ship(pk):
+def retrieve_ship(url):
     # Open a connection to the database
     with sqlite3.connect("./shipping.db") as conn:
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
 
-        # Write the SQL query to get the information you want
-        db_cursor.execute("""
-        SELECT
-            s.id,
-            s.name,
-            s.hauler_id
-        FROM Ship s
-        WHERE s.id = ?
-        """, (pk,))
-        query_results = db_cursor.fetchone()
+        query_params = url["query_params"].get("_expand", [])
+        pk = url["pk"]
+
+        # Check if query is requesting expanded data
+        if "hauler" in query_params:
+            db_cursor.execute("""
+            SELECT
+                s.id,
+                s.name,
+                s.hauler_id,
+                h.id haulerId,
+                h.name haulerName,
+                h.dock_id
+            FROM Ship s
+            JOIN Hauler h
+                ON h.id = s.hauler_id
+            WHERE s.id = ?
+            """, (pk,))
+        else:
+            db_cursor.execute("""
+            SELECT
+                s.id,
+                s.name,
+                s.hauler_id
+            FROM Ship s
+            WHERE s.id = ?
+            """, (pk,))
+
+        result = db_cursor.fetchone()
 
         # Serialize Python list to JSON encoded string
-        dictionary_version_of_object = dict(query_results)
-        serialized_ship = json.dumps(dictionary_version_of_object)
+        ship = {}
+        
+        if result:
+            ship = {
+                "id": result['id'],
+                "name": result['name'],
+                "hauler_id": result["hauler_id"]
+            }
+            if "hauler" in query_params:
+                hauler = {
+                    "id": result['haulerId'],
+                    "name": result['haulerName'],
+                    "dock_id": result["dock_id"]
+                }
+                ship["hauler"] = hauler
+        else:
+            ship = None
+        
+        serialized_ship = json.dumps(ship)
 
     return serialized_ship
 

--- a/views/ship_view.py
+++ b/views/ship_view.py
@@ -35,27 +35,59 @@ def delete_ship(pk):
     return True if number_of_rows_deleted > 0 else False
 
 
-def list_ships():
+def list_ships(url):
     # Open a connection to the database
     with sqlite3.connect("./shipping.db") as conn:
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
 
-        # Write the SQL query to get the information you want
-        db_cursor.execute("""
-        SELECT
-            s.id,
-            s.name,
-            s.hauler_id
-        FROM Ship s
-        """)
+        expand_list = url["query_params"].get("_expand", [])
+
+        # Check if query is requesting expanded data
+        # if "hauler" in url["query_params"]["_expand"]:
+        if "hauler" in expand_list:
+            # Write the SQL query to get the information you want
+            db_cursor.execute("""
+            SELECT
+                s.id,
+                s.name,
+                s.hauler_id,
+                h.id haulerId,
+                h.name haulerName,
+                h.dock_id
+            FROM Ship s
+            JOIN Hauler h
+                ON h.id = s.hauler_id
+            """)
+        else:
+            # Write the SQL query to get the information you want
+            db_cursor.execute("""
+            SELECT
+                s.id,
+                s.name,
+                s.hauler_id
+            FROM Ship s
+            """)
+
         query_results = db_cursor.fetchall()
 
         # Initialize an empty list and then add each dictionary to it
         ships=[]
         for row in query_results:
-            ships.append(dict(row))
-
+            ship = {
+                "id": row['id'],
+                "name": row['name'],
+                "hauler_id": row["hauler_id"]
+            }
+            if "hauler" in expand_list:
+                hauler = {
+                    "id": row['haulerId'],
+                    "name": row['haulerName'],
+                    "dock_id": row["dock_id"]
+                }
+                ship["hauler"] = hauler
+            ships.append(ship)
+        
         # Serialize Python list to JSON encoded string
         serialized_ships = json.dumps(ships)
 


### PR DESCRIPTION
### Purpose
To enable Users to request the Hauler data of the Hauler related to a ship when fetching one or more ships

### Files Changed
- Updated methods list_ships and retrieve_ship to handle embedding a Ships' Hauler based on a query param in `ship_view.py`
- Passed url to list_ships and retrieve_ship methods in `json-server.py`

### To Test
Fetch, setup, and run `json-server.py`, then confirm the following
- GET request `/ships` returns a list of all Ships as before
- GET request `/ships?_expand=hauler` returns a list of all Ships, with each Ship having their related Hauler embedded
- GET request `/ships/{id}` returns the appropriate Ship as before
- GET request `/ships/{id}?_expand=hauler` returns the appropriate Ship, with its related Hauler embedded